### PR TITLE
wip(short notation): initial short notation implementation

### DIFF
--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -132,6 +132,19 @@ if __name__ == "__main__":
     print("isvar: ", signal_obj.get_isvar(), end=" ")
     print("descr: ", signal_obj.get_descr())
 
+    print("\n\n")
+    wire_obj = py2hwsw.create_wire_from_text(
+        """
+            aoi_outs -s aab:W -s cad:W -s oab:1
+            -d 'AOI outputs'
+        """
+    )
+    print("wire_obj: ", wire_obj.get_name(), end=" ")
+    print("width: ", wire_obj.get_interface())
+    for signal in wire_obj.get_signals():
+        print("\tsignal: ", signal.get_name(), "width:", signal.get_width())
+    print("descr: ", wire_obj.get_descr())
+
     port_obj = py2hwsw.create_port_from_dict(
         {
             "name": "a_i",

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -124,8 +124,13 @@ if __name__ == "__main__":
         print(">>> Conf min: ", conf.get_min_value())
         print(">>> Conf max: ", conf.get_max_value())
         print(">>> Conf description: ", conf.get_descr())
-    print(">>> Name of conf_group_obj: ", conf_group_obj.get_name())
-    print(">>> Name of conf_obj: ", conf_group_obj.get_confs()[0].get_name())
+
+    print("\n\n")
+    signal_obj = py2hwsw.create_signal_from_text("en -w 1 -d 'Enable signal' -v")
+    print("signal_obj: ", signal_obj.get_name(), end=" ")
+    print("width: ", signal_obj.get_width(), end=" ")
+    print("isvar: ", signal_obj.get_isvar(), end=" ")
+    print("descr: ", signal_obj.get_descr())
 
     port_obj = py2hwsw.create_port_from_dict(
         {

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -80,38 +80,50 @@ if __name__ == "__main__":
 
     conf_obj = py2hwsw.create_conf_from_text(
         """
-        W -t P -v 21 -m 1 -M 32 
+        W -t P -v 21 -m 1 -M 32
         -d 'IO width'
         """
     )
 
-    # conf_groups_obj = py2hwsw.create_conf_group_from_text(
-    #     """
-    #     'Default group'
-    #     -d 'Default group of confs'
-    #     -doc
-    #     -doc_clearpage
-    #     --confs
-    #         DATA_W -t P -v 32 -m NA -M NA
-    #         -d 'Data bus width'
-    #
-    #         FRACTIONAL_W -t P -v 0 -m NA -M NA
-    #         -d 'Fractional part width'
-    #
-    #         REAL_W -t P -v 'DATA_W - FRACTIONAL_W' -m NA -M NA
-    #         -d 'Real part width'
-    #
-    #         SIZE_W -t P -v '(REAL_W / 2) + FRACTIONAL_W' -m NA -M NA
-    #         -d 'Size width'
-    #
-    #         END_COUNT -t D -v '(DATA_W + FRACTIONAL_W) >> 1' -m NA -M NA
-    #         -d 'End count'
-    #
-    #         COUNT_W -t D -v $clog2(END_COUNT) -m NA -M NA
-    #         -d 'Count width'
-    #     """
-    # )
-    breakpoint()
+    conf_groups_obj = py2hwsw.create_conf_group_from_text(
+        """
+        'Default group'
+        -d 'Default group of confs'
+        -doc
+        -doc_clearpage
+        --confs
+            "
+            DATA_W -t P -v 32 -m NA -M NA
+            -d 'Data bus width'
+
+            FRACTIONAL_W -t P -v 0 -m NA -M NA
+            -d 'Fractional part width'
+
+            REAL_W -t P -v 'DATA_W - FRACTIONAL_W' -m NA -M NA
+            -d 'Real part width'
+
+            SIZE_W -t P -v '(REAL_W / 2) + FRACTIONAL_W' -m NA -M NA
+            -d 'Size width'
+
+            END_COUNT -t D -v '(DATA_W + FRACTIONAL_W) >> 1' -m NA -M NA
+            -d 'End count'
+
+            COUNT_W -t D -v $clog2(END_COUNT) -m NA -M NA
+            -d 'Count width'
+            "
+        """
+    )
+    print(conf_groups_obj.get_name())
+    print(conf_groups_obj.get_descr())
+    print(conf_groups_obj.get_doc_only())
+    print(conf_groups_obj.get_doc_clearpage())
+    for conf in conf_groups_obj.get_confs():
+        print(">>> Conf name: ", conf.get_name())
+        print(">>> Conf kind: ", conf.get_kind())
+        print(">>> Conf value: ", conf.get_value())
+        print(">>> Conf min: ", conf.get_min_value())
+        print(">>> Conf max: ", conf.get_max_value())
+        print(">>> Conf description: ", conf.get_descr())
     print(">>> Name of conf_group_obj: ", conf_group_obj.get_name())
     print(">>> Name of conf_obj: ", conf_group_obj.get_confs()[0].get_name())
 

--- a/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
+++ b/py2hwsw/lib/hardware/basic_tests/iob_and/iob_and.py
@@ -77,6 +77,41 @@ if __name__ == "__main__":
             ],
         },
     )
+
+    conf_obj = py2hwsw.create_conf_from_text(
+        """
+        W -t P -v 21 -m 1 -M 32 
+        -d 'IO width'
+        """
+    )
+
+    # conf_groups_obj = py2hwsw.create_conf_group_from_text(
+    #     """
+    #     'Default group'
+    #     -d 'Default group of confs'
+    #     -doc
+    #     -doc_clearpage
+    #     --confs
+    #         DATA_W -t P -v 32 -m NA -M NA
+    #         -d 'Data bus width'
+    #
+    #         FRACTIONAL_W -t P -v 0 -m NA -M NA
+    #         -d 'Fractional part width'
+    #
+    #         REAL_W -t P -v 'DATA_W - FRACTIONAL_W' -m NA -M NA
+    #         -d 'Real part width'
+    #
+    #         SIZE_W -t P -v '(REAL_W / 2) + FRACTIONAL_W' -m NA -M NA
+    #         -d 'Size width'
+    #
+    #         END_COUNT -t D -v '(DATA_W + FRACTIONAL_W) >> 1' -m NA -M NA
+    #         -d 'End count'
+    #
+    #         COUNT_W -t D -v $clog2(END_COUNT) -m NA -M NA
+    #         -d 'Count width'
+    #     """
+    # )
+    breakpoint()
     print(">>> Name of conf_group_obj: ", conf_group_obj.get_name())
     print(">>> Name of conf_obj: ", conf_group_obj.get_confs()[0].get_name())
 

--- a/py2hwsw/scripts/api_base.py
+++ b/py2hwsw/scripts/api_base.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+import argparse
 import inspect
 import importlib
+import shlex
 
 from dataclasses import field
 
@@ -401,3 +403,50 @@ def internal_api_class(api_module, api_class_name, allow_unknown_args=False):
         return cls
 
     return decorator
+
+
+def create_short_notation_parser(flags: list) -> argparse.ArgumentParser:
+    """Create Short Notation Parser
+    Attributes:
+        flags (list): List of flags to be used in the parser.
+            each list element can be:
+            - string (single name for default arguments)
+            - list with [flag, dict].
+                flag: argument name/flag
+                dict: argparse optional arguments.
+            Example:
+                example_flags = [
+                    "name",
+                    ["-v", {"dest": "value"}],
+                    ["-d", {"dest": "descr", "nargs": "?"}],
+                    ["-doc", {"dest": "doc_only", "action": "store_true"}],
+                ]
+    Returns:
+        argparse.ArgumentParser: Argument parser with the specified flags.
+    """
+    parser = argparse.ArgumentParser()
+    for flag in flags:
+        if isinstance(flag, str):
+            parser.add_argument(flag)
+        elif isinstance(flag, list):
+            parser.add_argument(flag[0], **flag[1])
+        else:
+            raise ValueError(f"ERROR: unsupported flag format: {flag}")
+    return parser
+
+
+def parse_short_notation_text(text: str, flags) -> dict:
+    """Parse Short Notation Text
+    Arguments:
+        text (str): Short notation text to be parsed.
+        flags (list): List of flags to be used in the parser.
+            See create_short_notation_parser() for details.
+    Returns:
+        dict: Parsed short text as flags dictionary.
+    """
+    # preprocess short notation text
+    pre_process_conf_text = shlex.split(text.strip('\n'))
+    # create argument parser
+    parser = create_short_notation_parser(flags)
+    # parse and return text as dict
+    return parser.parse_args(pre_process_conf_text).__dict__

--- a/py2hwsw/scripts/iob_conf.py
+++ b/py2hwsw/scripts/iob_conf.py
@@ -165,7 +165,6 @@ def conf_from_text(conf_text: str) -> iob_conf:
         ["-doc", {"dest": "doc_only", "action": "store_true"}],
     ]
     conf_dict = parse_short_notation_text(conf_text, conf_text_flags)
-    print(f"DEBUG: {conf_dict}")
     return iob_conf(**conf_dict)
 
 
@@ -178,7 +177,22 @@ def conf_group_from_dict(conf_group_dict):
     return iob_conf_group(**conf_group_dict)
 
 
-def conf_group_from_text(conf_group_text):
-    conf_group_dict = {}
-    # TODO: parse short notation text
+def conf_group_from_text(conf_group_text: str):
+    # Create conf_group from short notation text
+    conf_group_flags = [
+        "name",
+        ["--confs", {"dest": "confs"}],
+        ["-doc", {"dest": "doc_only", "action": "store_true"}],
+        ["-doc_clearpage", {"dest": "doc_clearpage", "action": "store_true"}],
+        ["-d", {"dest": "descr"}],
+    ]
+    # Parse conf group text into a dictionary
+    conf_group_dict = parse_short_notation_text(conf_group_text, conf_group_flags)
+
+    # Special processing for conf subflags
+    confs: list[iob_conf] = []
+    for conf_text in conf_group_dict.get("confs", "").split('\n\n'):
+        confs.append(conf_from_text(conf_text))
+    # replace "confs" short notation text with list of conf objects
+    conf_group_dict.update({"confs": confs})
     return iob_conf_group(**conf_group_dict)

--- a/py2hwsw/scripts/iob_conf.py
+++ b/py2hwsw/scripts/iob_conf.py
@@ -153,9 +153,55 @@ def conf_from_dict(conf_dict):
     return iob_conf(**conf_dict)
 
 
-def conf_from_text(conf_text):
-    conf_dict = {}
-    # TODO: parse short notation text
+import argparse
+import shlex
+
+
+def short_notation_create_parser(flags: list) -> argparse.ArgumentParser:
+    """
+    TODO:
+    - import argparse
+    - or add this to iob_base.py or short_notation.py
+    """
+    breakpoint()
+    parser = argparse.ArgumentParser()
+    for flag in flags:
+        if isinstance(flag, str):
+            parser.add_argument(flag)
+        elif isinstance(flag, list):
+            parser.add_argument(flag[0], **flag[1])
+        else:
+            raise ValueError(f"ERROR: unsupported flag format: {flag}")
+    breakpoint()
+    return parser
+
+
+def _conf_parse_text(conf_text: str) -> dict:
+    # parse conf text into a dictionary
+    conf_text_flags = [
+        "name",
+        ["-t", {"dest": "kind"}],
+        ["-v", {"dest": "value"}],
+        ["-m", {"dest": "min_value"}],
+        ["-M", {"dest": "max_value"}],
+        ["-d", {"dest": "descr", "nargs": "?"}],
+        ["-doc", {"dest": "doc_only", "action": "store_true"}],
+    ]
+
+    # preprocess short notation text
+    pre_process_conf_text = shlex.split(conf_text.strip('\n'))
+    # create argument parser
+    parser = short_notation_create_parser(conf_text_flags)
+    print(f"DEBUG: pre_process_conf_text = {pre_process_conf_text}")
+    breakpoint()
+    # parse and return conf_text as dict
+    return parser.parse_args(pre_process_conf_text).__dict__
+
+
+def conf_from_text(conf_text: str) -> iob_conf:
+    conf_dict = _conf_parse_text(conf_text)
+    print(f"DEBUG: {conf_dict}")
+    breakpoint()
     return iob_conf(**conf_dict)
 
 

--- a/py2hwsw/scripts/iob_conf.py
+++ b/py2hwsw/scripts/iob_conf.py
@@ -12,7 +12,7 @@ from iob_base import (
     find_obj_in_list,
 )
 
-from api_base import internal_api_class
+from api_base import internal_api_class, parse_short_notation_text
 
 
 @internal_api_class("user_api.api", "iob_conf")
@@ -153,30 +153,7 @@ def conf_from_dict(conf_dict):
     return iob_conf(**conf_dict)
 
 
-import argparse
-import shlex
-
-
-def short_notation_create_parser(flags: list) -> argparse.ArgumentParser:
-    """
-    TODO:
-    - import argparse
-    - or add this to iob_base.py or short_notation.py
-    """
-    breakpoint()
-    parser = argparse.ArgumentParser()
-    for flag in flags:
-        if isinstance(flag, str):
-            parser.add_argument(flag)
-        elif isinstance(flag, list):
-            parser.add_argument(flag[0], **flag[1])
-        else:
-            raise ValueError(f"ERROR: unsupported flag format: {flag}")
-    breakpoint()
-    return parser
-
-
-def _conf_parse_text(conf_text: str) -> dict:
+def conf_from_text(conf_text: str) -> iob_conf:
     # parse conf text into a dictionary
     conf_text_flags = [
         "name",
@@ -187,21 +164,8 @@ def _conf_parse_text(conf_text: str) -> dict:
         ["-d", {"dest": "descr", "nargs": "?"}],
         ["-doc", {"dest": "doc_only", "action": "store_true"}],
     ]
-
-    # preprocess short notation text
-    pre_process_conf_text = shlex.split(conf_text.strip('\n'))
-    # create argument parser
-    parser = short_notation_create_parser(conf_text_flags)
-    print(f"DEBUG: pre_process_conf_text = {pre_process_conf_text}")
-    breakpoint()
-    # parse and return conf_text as dict
-    return parser.parse_args(pre_process_conf_text).__dict__
-
-
-def conf_from_text(conf_text: str) -> iob_conf:
-    conf_dict = _conf_parse_text(conf_text)
+    conf_dict = parse_short_notation_text(conf_text, conf_text_flags)
     print(f"DEBUG: {conf_dict}")
-    breakpoint()
     return iob_conf(**conf_dict)
 
 

--- a/py2hwsw/scripts/iob_signal.py
+++ b/py2hwsw/scripts/iob_signal.py
@@ -8,7 +8,7 @@ import copy
 from iob_base import fail_with_msg
 
 
-from api_base import internal_api_class
+from api_base import internal_api_class, parse_short_notation_text
 
 
 @internal_api_class("user_api.api", "iob_signal")
@@ -105,6 +105,11 @@ def signal_from_dict(signal_dict):
 
 
 def signal_from_text(signal_text):
-    signal_dict = {}
-    # TODO: parse short notation text
+    signal_flags = [
+        "name",
+        ["-w", {"dest": "width"}],
+        ["-v", {"dest": "isvar", "action": "store_true"}],
+        ["-d", {"dest": "descr", "nargs": "?"}],
+    ]
+    signal_dict = parse_short_notation_text(signal_text, signal_flags)
     return iob_signal(**signal_dict)

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -228,9 +228,6 @@ class iob_signal:
         width (str or int): Number of bits in the signal.
         descr (str): Description of the signal.
         isvar (bool): If enabled, signal will be generated with type `reg` in Verilog.
-        # isreg (bool): Used for `iob_comb`: If enabled, iob_comb will infer a register for this signal.
-        # reg_signals (list): Used for `iob_comb`: List of signals associated to the infered register.
-        # value (str or int): Logic value for future simulation effort using global signals list.
     """
 
     name: str = ""
@@ -251,9 +248,6 @@ def create_signal_from_dict(signal_dict):
             - width         -> iob_signal.width
             - descr         -> iob_signal.descr
             - isvar         -> iob_signal.isvar
-            - isreg         -> iob_signal.isreg
-            - reg_signals   -> iob_signal.reg_signals
-            - val           -> iob_signal.value
 
     Returns:
         iob_signal: iob_signal object
@@ -268,7 +262,9 @@ def create_signal_from_text(signal_text):
 
     Attributes:
         signal_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-w width] [-d descr] [-r (enables isreg)] [-v value]
+            name [-w width] [-d descr] [-v (enables isvar)]
+            Example:
+                en -w 1 -d 'Enable signal' -v
 
     Returns:
         iob_signal: iob_signal object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -392,7 +392,9 @@ def create_wire_from_text(wire_text):
 
     Attributes:
         wire_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-i interface] [-d descr] [-s signal_name:width]+
+            name [-i interface] [-d descr] [-s signal_name1:width1] [-s signal_name2:width2]+
+            Examples:
+                dbus -d 'data bus' -s wdata:32 -s wstrb:4
 
     Returns:
         iob_wire: iob_wire object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -126,28 +126,6 @@ def create_conf_from_dict(conf_dict):
     pass
 
 
-# Example confs:
-# "confs": [
-#     """
-#     DATA_W -t P -v 32 -m NA -M NA
-#     -d 'Data bus width'
-#
-#     FRACTIONAL_W -t P -v 0 -m NA -M NA
-#     -d 'Fractional part width'
-#
-#     REAL_W -t P -v 'DATA_W - FRACTIONAL_W' -m NA -M NA
-#     -d 'Real part width'
-#
-#     SIZE_W -t P -v '(REAL_W / 2) + FRACTIONAL_W' -m NA -M NA
-#     -d 'Size width'
-#
-#     END_COUNT -t D -v '(DATA_W + FRACTIONAL_W) >> 1' -m NA -M NA
-#     -d 'End count'
-#
-#     COUNT_W -t D -v $clog2(END_COUNT) -m NA -M NA
-#     -d 'Count width'
-#     """,
-# ],
 @api_for(internal_conf.conf_from_text)
 def create_conf_from_text(conf_text):
     """
@@ -157,9 +135,9 @@ def create_conf_from_text(conf_text):
         conf_text (str): Short notation text. Object attributes are specified using the following format:
             name [-t kind] [-v value] [-m min_value] [-M max_value] [-doc]
             [-d descr]
-        Example:
-            DATA_W -t P -v 32 -m NA -M NA
-            -d 'Data bus width'
+            Example:
+                DATA_W -t P -v 32 -m NA -M NA
+                -d 'Data bus width'
 
     Returns:
         iob_conf: iob_conf object
@@ -214,7 +192,20 @@ def create_conf_group_from_text(conf_group_text):
 
     Attributes:
         conf_group_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-c confs]
+            name [-d descr] [--confs] [-doc] [-doc_clearpage]
+            Example:
+                'Default group'
+                -d 'Default group of confs'
+                -doc
+                -doc_clearpage
+                --confs
+                    "
+                    DATA_W -t P -v 32 -m NA -M NA
+                    -d 'Data bus width'
+
+                    ADDR_W -t P -v 4 -m NA -M NA
+                    -d 'Address width'
+                    "
 
     Returns:
         iob_conf_group: iob_conf_group object

--- a/py2hwsw/scripts/user_api/api.py
+++ b/py2hwsw/scripts/user_api/api.py
@@ -126,6 +126,28 @@ def create_conf_from_dict(conf_dict):
     pass
 
 
+# Example confs:
+# "confs": [
+#     """
+#     DATA_W -t P -v 32 -m NA -M NA
+#     -d 'Data bus width'
+#
+#     FRACTIONAL_W -t P -v 0 -m NA -M NA
+#     -d 'Fractional part width'
+#
+#     REAL_W -t P -v 'DATA_W - FRACTIONAL_W' -m NA -M NA
+#     -d 'Real part width'
+#
+#     SIZE_W -t P -v '(REAL_W / 2) + FRACTIONAL_W' -m NA -M NA
+#     -d 'Size width'
+#
+#     END_COUNT -t D -v '(DATA_W + FRACTIONAL_W) >> 1' -m NA -M NA
+#     -d 'End count'
+#
+#     COUNT_W -t D -v $clog2(END_COUNT) -m NA -M NA
+#     -d 'Count width'
+#     """,
+# ],
 @api_for(internal_conf.conf_from_text)
 def create_conf_from_text(conf_text):
     """
@@ -133,7 +155,11 @@ def create_conf_from_text(conf_text):
 
     Attributes:
         conf_text (str): Short notation text. Object attributes are specified using the following format:
-            name [-t kind] [-v value] [-m min_value] [-M max_value]
+            name [-t kind] [-v value] [-m min_value] [-M max_value] [-doc]
+            [-d descr]
+        Example:
+            DATA_W -t P -v 32 -m NA -M NA
+            -d 'Data bus width'
 
     Returns:
         iob_conf: iob_conf object


### PR DESCRIPTION
currently implemented for:
- [x] iob_conf
- [x] iob_conf_group
- [x] iob_signal
- [x] iob_wire (only with signals, still need to implement with interfaces)

added examples in  `iob_and.py`